### PR TITLE
Disable station traits and station events

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -472,17 +472,17 @@
 /datum/config_entry/string/new_player_alert_role_id
 
 /datum/config_entry/keyed_list/positive_station_traits
-	default = list("0" = 100) // ARMOK EDIT
+	default = list("0" = 8, "1" = 4, "2" = 2, "3" = 1)
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_NUM
 
 /datum/config_entry/keyed_list/negative_station_traits
-	default = list("0" = 100) // ARMOK EDIT
+	default = list("0" = 8, "1" = 4, "2" = 2, "3" = 1)
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_NUM
 
 /datum/config_entry/keyed_list/neutral_station_traits
-	default = list("0" = 100) // ARMOK EDIT
+	default = list("0" = 10, "1" = 10, "2" = 3, "2.5" = 1)
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_NUM
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -141,10 +141,10 @@ DYNAMIC_CONFIG_ENABLED
 
 ## RANDOM EVENTS ###
 ## Comment this out to disable random events during the round.
-ALLOW_RANDOM_EVENTS
+#ALLOW_RANDOM_EVENTS
 
 ## Uncomment this to disable station traits.
-#FORBID_STATION_TRAITS
+FORBID_STATION_TRAITS
 
 ## Multiplier for earliest start time of dangerous events.
 ## Set to 0 to make dangerous events available from round start.


### PR DESCRIPTION

## About The Pull Request
Initially tried to do this for station traits via:
- #3

But it didn't work like I expected. Turns out there is a really simple config option that does this automatically. 

I would like to rework station events at some point in the future to be planetary based events that revolve around the fortress but for now none of those events are compatible. Part of this is due to a lot of `/area` checks that look for `/area/station` subtypes which aren't used for our maps.

Reworking it would require:
- Blacklist all incompatible station events (almost all of them)
- Balancing timing that don't revolve around 1 hour shifts
- Modularizing Armok events

Basically it's not important to do right now.

## Why It's Good For The Game
Incompatible code for the Armok server. 

## Changelog
:cl:
config: Disable station traits (for real this time) and events
/:cl:
